### PR TITLE
PIL-1943 Add Google Tag to Pillar 2 Service Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Service guide microservice for Pillar 2 project. Pillar 2 refers to the Global M
 The Pillar 2 Tax will ensure that global Multinational Enterprises (MNEs) with a turnover of >€750m are subject to a minimum Effective Tax Rate of 15%, i.e. a top-up tax for Medium to Large MNEs.
 
 ## Prerequisites
-```
+```shell
 brew install rbenv
 brew install nodenv
 ```
@@ -18,7 +18,6 @@ Template files are located in `./source/documentation`. All pages are written in
 
 To add new pages simply copy and paste one of the existing pages, it will automatically appear in the menu.
 
-`example-page.html.md.erb` provides examples and best practices styles.
 
 ## Previewing
 
@@ -28,7 +27,7 @@ Requirements:
 * [Docker](https://www.docker.com/)
 
 To live preview:
-```
+```shell
 ./batect preview
 ```
 The local URL and port where the files can be previewed will be output, this is normally http://localhost:4567.
@@ -43,7 +42,7 @@ Requirements:
 * [Node Version Manager][nodenv]
 
 To live preview:
-```
+```shell
 bundle install
 bundle exec middleman serve
 ```
@@ -55,11 +54,12 @@ Requirements:
 * Scala/sbt
 
 ### Build the HTML files
-```
+```shell
 ./batect build
 ```
+
 ### Run the Scala Application
-```
+```shell
 sbt run
 ```
 
@@ -70,7 +70,7 @@ The local URL and port where the files can be previewed will be output, this is 
 
 ### How do I update the Ruby Gems
 To update the Ruby Gems to the latest versions, run
-```
+```shell
 ./batect update
 ```
 This will update the `Gemfile.lock`
@@ -78,13 +78,12 @@ This will update the `Gemfile.lock`
 ### How do I change the Ruby version
 Edit `.ruby-version` with the required version of Ruby.
 
-
 ### How do I change the Node version
 Edit `.node-version` with the required version of Node.
 
-[tdt]: https://github.com/alphagov/tech-docs-template
-[rbenv]: https://github.com/rbenv/rbenv
-[nodenv]: https://github.com/nodenv/nodenv
-
 ## License
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").
+
+
+[rbenv]: https://github.com/rbenv/rbenv
+[nodenv]: https://github.com/nodenv/nodenv

--- a/source/documentation/partials/_google_tag_js.html.erb
+++ b/source/documentation/partials/_google_tag_js.html.erb
@@ -1,0 +1,11 @@
+<% content_for :head do %>
+<!-- Google Tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=Y4LWMWY6WS"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-Y4LWMWY6WS');
+</script>
+<% end %>

--- a/source/documentation/partials/_google_tag_manager_js.html.erb
+++ b/source/documentation/partials/_google_tag_manager_js.html.erb
@@ -1,9 +1,10 @@
 <% content_for :head do %>
 <!--[if !IE]>-->
 <script
-src="<%= config[:tech_docs][:tracking_consent_frontend][:url] %>"
-id="tracking-consent-script-tag"
-data-gtm-container="<%= config[:tech_docs][:tracking_consent_frontend][:gtm_container] %>"
-data-language="en"></script>
+  src="<%= config[:tech_docs][:tracking_consent_frontend][:url] %>"
+  id="tracking-consent-script-tag"
+  data-gtm-container="<%= config[:tech_docs][:tracking_consent_frontend][:gtm_container] %>"
+  data-language="en">
+</script>
 <!--<![endif]-->
 <% end %>

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -4,5 +4,5 @@ weight: 1
 
 <%= partial 'documentation/partials/google_tag_js' %>
 <%= partial 'documentation/partials/google_tag_manager_js' %>
-<%= partial "documentation/partials/give-feedback" %>
+<%= partial 'documentation/partials/give-feedback' %>
 <%= partial 'documentation/index' %>

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -2,6 +2,7 @@
 weight: 1
 ---
 
+<%= partial 'documentation/partials/google_tag_js' %>
 <%= partial 'documentation/partials/google_tag_manager_js' %>
 <%= partial "documentation/partials/give-feedback" %>
 <%= partial 'documentation/index' %>


### PR DESCRIPTION
- Added the Google Tag script to the `<head>` of the service guide
- Fixed formatting to the existing Google Tag Manager script
- Minor improvements to the README file