### PR TITLE
PIL-1943 Fixed Google Analytics CSP issue

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -25,7 +25,7 @@ appUrl = "http://"${appName}".local"
 # Additional play modules can be added here
 
 # Note that Hash value script-src will need to be changed if any of the javascript is changed - get the new value from your browser console.
-play.filters.headers.contentSecurityPolicy= "script-src 'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=' 'self'; object-src 'none'; base-uri 'none' "
+play.filters.headers.contentSecurityPolicy= "script-src 'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw=' 'sha256-66uZ603bzfVWO8dV3lSbsWCvpMREkRQuGqfiG9mkKlE=' 'self' https://*.googletagmanager.com; object-src 'none'; base-uri 'none'"
 
 # Session Timeout
 # ~~~~

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 
 object AppDependencies {
   lazy val bootStrapPlayVersion = "9.11.0"
-  lazy val pegdownVersion       = "1.6.0"
+  lazy val flexmarkAllVersion   = "0.64.8"
 
   lazy val compile: Seq[ModuleID] = Seq(
     ws,
@@ -11,7 +11,7 @@ object AppDependencies {
   )
 
   lazy val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc" %% "bootstrap-test-play-30" % bootStrapPlayVersion,
-    "org.pegdown"  % "pegdown"                % pegdownVersion
+    "uk.gov.hmrc"         %% "bootstrap-test-play-30" % bootStrapPlayVersion,
+    "com.vladsch.flexmark" % "flexmark-all"           % flexmarkAllVersion
   ).map(_ % Test)
 }


### PR DESCRIPTION
- Updated hash for `script-src`
- Whitelisted `https://*.googletagmanager.com` in the CSP settings
- Replaced pegdown by flexmark-all
