### PR TITLE
update account activity weight

### DIFF
--- a/source/documentation/account-activity.html.md
+++ b/source/documentation/account-activity.html.md
@@ -1,6 +1,6 @@
 ---
 title: Retrieve Account Activity | Pillar 2 Service Guide
-weight: 9
+weight: 10
 ---
 
 # Retrieve account activity


### PR DESCRIPTION
within the service guide, account activity was assigned a weight of 9, which matched the weight of retrieve ORN. Account activity has been changed to a weight of 10 to remove unpredictability.