### PR TITLE
Add changes regarding UKTR submission for MNE vs domestic

### DIFF
--- a/source/documentation/submitORN.html.md
+++ b/source/documentation/submitORN.html.md
@@ -102,7 +102,7 @@ If a duplicate submission is received, a 422 client error response with code "04
   "errors": {
     "processingDate": "2025-03-17T09:26:17Z",
     "code": "044",
-    "message": "Tax obligation already fulfilled"
+    "message": "Tax obligation already fulfilled. A ORN for the specified period has already been submitted."
   }
 }
 ```

--- a/source/documentation/submitUKTR.html.md
+++ b/source/documentation/submitUKTR.html.md
@@ -28,19 +28,19 @@ The table here contains some information on the differences between the request 
 <tbody>
 <tr>
 <td>Nil Return (MNE/UK)</td>
-<td>The <em>obligationMTT</em> field cannot be set to "true" for a domestic (UK only) group.</td>
+<td>The <em>obligationMTT</em> field can be set to "true" or "false" for a multinational group.</td>
 </tr>
 <tr>
 <td>Nil Return (UK Only)</td>
-<td>The <em>obligationMTT</em> field is set to "false".</td>
+<td>The <em>obligationMTT</em> field must be set to "false".</td>
 </tr>
 <tr>
 <td>Liability return (MNE/UK)</td>
-<td>Request includes totals for DTT, IIR, UTPR and overall total. The <em>obligationMTT</em> field cannot be set to "true" for a domestic (UK only) group.</td>
+<td>Request includes totals for DTT, IIR, UTPR and overall total. The <em>obligationMTT</em> field cannot be set to "true" for a domestic (UK only) group. A domestic only or multinational can be liable for DTT. </td>
 </tr>
 <tr>
 <td>Liability return (UK Only)</td>
-<td>Request includes totals for DTT and overall total. The <em>obligationMTT</em> field is set to "false" and the MTT fields <em>totalLiabilityIIR</em>, <em>amountOwedIIR</em>, <em>totalLiabilityUTPR</em> and <em>amountOwedUTPR</em> are all set to 0, or the request is rejected. </td>
+<td>Request includes totals for DTT and overall total. The <em>obligationMTT</em> field is set to "false" and the MTT fields <em>totalLiabilityIIR</em>, <em>amountOwedIIR</em>, <em>totalLiabilityUTPR</em> and <em>amountOwedUTPR</em> are all set to 0, or the request is rejected. A domestic only or multinational can be liable for DTT.</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Added changes to service guide to reflect feedback on fields being set to true or false depending on whether the submission is from an MNE or a domestic-only group.